### PR TITLE
fix(search): Use AND operator for multi-word searches

### DIFF
--- a/server/services/search/searchService.ts
+++ b/server/services/search/searchService.ts
@@ -89,6 +89,7 @@ export class SearchService {
     const results = index.search(normalizedQuery, {
       prefix: options.prefix ?? true,
       fuzzy: options.fuzzy ?? 0.2,
+      combineWith: 'AND',
       boost: {
         title: 2,
         artists: 1.5


### PR DESCRIPTION
## Summary
- Fixed search functionality to require ALL search terms instead of ANY term
- Changed MiniSearch configuration to use `combineWith: 'AND'` operator
- Resolves issue where searching "john coltrane" returned unrelated artists

## Changes
- Modified `server/services/collectionService.ts:417`
- Added `combineWith: 'AND'` to MiniSearch query options

## Test plan
- Restart server and search for "john coltrane"
- Verify only relevant results are returned