### PR TITLE
Fix: Preserve desktop layout and improve mobile filter module responsiveness

### DIFF
--- a/client/src/components/CollectionFilters.vue
+++ b/client/src/components/CollectionFilters.vue
@@ -104,7 +104,8 @@ watch(
     variant="default"
     class="mx-4 mb-4 !bg-white/60 dark:!bg-[#181818]/60 backdrop-blur-lg border border-gray-200/30 dark:border-gray-700/30 !shadow-sm"
   >
-    <div class="flex items-center gap-4 flex-wrap">
+    <!-- Mobile: grid with centered controls, Desktop: flex row -->
+    <div class="grid grid-cols-1 gap-4 sm:flex sm:items-center sm:gap-4 sm:flex-wrap">
       <!-- Sort Order Toggle Button -->
       <!-- <div class="flex-shrink-0">
         <Button
@@ -120,7 +121,7 @@ watch(
       </div> -->
 
       <!-- Genre/Folder Dropdown -->
-      <div class="min-w-[200px] flex-shrink-0">
+      <div class="w-full max-w-[420px] mx-auto sm:mx-0 sm:min-w-[200px] sm:max-w-none sm:flex-shrink-0">
         <Select
           :model-value="currentFolder"
           :options="folderOptions"
@@ -134,7 +135,7 @@ watch(
       </div>
 
       <!-- Sort Field Dropdown -->
-      <div class="min-w-[180px] flex-shrink-0">
+      <div class="w-full max-w-[420px] mx-auto sm:mx-0 sm:min-w-[180px] sm:max-w-none sm:flex-shrink-0">
         <Select
           :model-value="currentSort"
           :options="sortOptions"
@@ -148,7 +149,7 @@ watch(
       </div>
 
       <!-- Search Bar -->
-      <div class="min-w-[350px] flex-grow">
+      <div class="w-full max-w-[420px] mx-auto sm:mx-0 sm:min-w-[350px] sm:max-w-none sm:flex-grow">
         <Input
           v-model="searchQuery"
           type="search"

--- a/client/src/components/CollectionFilters.vue
+++ b/client/src/components/CollectionFilters.vue
@@ -104,8 +104,8 @@ watch(
     variant="default"
     class="mx-4 mb-4 !bg-white/60 dark:!bg-[#181818]/60 backdrop-blur-lg border border-gray-200/30 dark:border-gray-700/30 !shadow-sm"
   >
-    <!-- Mobile: grid with centered controls, Desktop: flex row -->
-    <div class="grid grid-cols-1 gap-4 sm:flex sm:items-center sm:gap-4 sm:flex-wrap">
+    <!-- Mobile: flex-col (vertical), Desktop: flex-row (horizontal) -->
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:flex-wrap">
       <!-- Sort Order Toggle Button -->
       <!-- <div class="flex-shrink-0">
         <Button
@@ -121,7 +121,7 @@ watch(
       </div> -->
 
       <!-- Genre/Folder Dropdown -->
-      <div class="w-full max-w-[420px] mx-auto sm:mx-0 sm:min-w-[200px] sm:max-w-none sm:flex-shrink-0">
+      <div class="w-full max-w-[420px] mx-auto sm:mx-0 sm:w-auto sm:min-w-[200px] sm:flex-shrink-0">
         <Select
           :model-value="currentFolder"
           :options="folderOptions"
@@ -135,7 +135,7 @@ watch(
       </div>
 
       <!-- Sort Field Dropdown -->
-      <div class="w-full max-w-[420px] mx-auto sm:mx-0 sm:min-w-[180px] sm:max-w-none sm:flex-shrink-0">
+      <div class="w-full max-w-[420px] mx-auto sm:mx-0 sm:w-auto sm:min-w-[180px] sm:flex-shrink-0">
         <Select
           :model-value="currentSort"
           :options="sortOptions"
@@ -149,7 +149,7 @@ watch(
       </div>
 
       <!-- Search Bar -->
-      <div class="w-full max-w-[420px] mx-auto sm:mx-0 sm:min-w-[350px] sm:max-w-none sm:flex-grow">
+      <div class="w-full max-w-[420px] mx-auto sm:mx-0 sm:w-auto sm:min-w-[350px] sm:flex-grow">
         <Input
           v-model="searchQuery"
           type="search"

--- a/client/src/components/Nav/AppNavbar.vue
+++ b/client/src/components/Nav/AppNavbar.vue
@@ -61,7 +61,7 @@ onUnmounted(() => {
           <img
             src="/space-is-the-place-logo.png"
             alt="Space Is The Place Logo"
-            class="h-7 sm:h-8 md:h-[65px] w-auto object-contain"
+            class="h-8 sm:h-8 md:h-[65px] w-auto object-contain shrink-0"
           />
         </button>
       </div>

--- a/client/src/views/CollectionView.vue
+++ b/client/src/views/CollectionView.vue
@@ -229,14 +229,15 @@ onUnmounted(() => {
 <style scoped>
 .collection-container {
   max-width: 1600px;
-  padding-left: 16px;
-  padding-right: 16px;
+  /* Mobile: safe-area padding + base padding */
+  padding-left: max(16px, env(safe-area-inset-left));
+  padding-right: max(16px, env(safe-area-inset-right));
 }
 
 @media (min-width: 1360px) {
   .collection-container {
-    padding-left: 8px;
-    padding-right: 8px;
+    padding-left: max(8px, env(safe-area-inset-left));
+    padding-right: max(8px, env(safe-area-inset-right));
   }
 }
 


### PR DESCRIPTION
This PR restores the original desktop layout of the filter module on the Collection page, while keeping the new mobile improvements introduced previously.

Changes included:

- Restored horizontal alignment of filter controls (Genre, Sort by, Search) on desktop view

- Maintained enhanced mobile layout (centered controls, proper padding, no horizontal clipping)

- Adjusted Tailwind breakpoints to ensure clean separation between mobile and desktop styles

- Verified responsive behavior across iOS Safari, Android Chrome, and desktop browsers

Result:
The filter module now looks clean and consistent across all devices — no more clipping on mobile, and the original elegant horizontal layout is preserved on desktop.